### PR TITLE
Fix for Docker "Legacy" mountpoint errors

### DIFF
--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -175,7 +175,7 @@ class OMVModuleZFSUtil {
 			$filesystem->updateProperty("mountpoint");
 			$name = $filesystem->getName();
 			$mntpoint = $filesystem->getMountPoint();
-			if($mntpoint!="none")
+			if (($mntpoint != "none") && ($mntpoint !== "legacy"))
 				$current[] = ["fsname"=>$name, "dir"=>$mntpoint];
 		}
 		$prev = Rpc::call("FsTab","enumerateEntries",[],$context);


### PR DESCRIPTION
When you're using Docker and you select a ZFS dataset for its base path, Docker uses its ZFS driver and creates a ton of different clones and a few actual filesystems. All of these have the mountpoint of "legacy" set on the clones/datasets, and this causes an error with the ZFS plugin's "fixOMVMntEnt" function. 

This change "fixes" the issue by excluding any filesystems with a mountpoint of "legacy", in addition to the exclusion of anything with "none" as the mountpoint. Since OMV has no real need to know about the Docker filesystems, this seems safe enough; the datasets/clones can still be viewed and managed within the ZFS plugin, they just won't show as mount entities in /etc/openmediavault/config.xml.