### PR TITLE
Add mntent uuid into zfs property for every dataset

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -x
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions
@@ -27,24 +27,28 @@ case "$1" in
 
         /sbin/modprobe zfs
 
-        if modinfo zfs >/dev/null 2>/dev/null && ! modprobe -n --first-time zfs 2>/dev/null; then
-            zfsMntent_entries=$(omv-confdbadm read conf.system.filesystem.mountpoint \
-                | jq -r '.[]|select(.type=="zfs")')
-            zfsMntent_uuid=( $(echo "$zfsMntent_entries" | jq -r '.uuid') )
-            zfsMntent_fsname=( $(echo "$zfsMntent_entries" | jq -r '.fsname') )
-            j=0
-            echo ${zfsMntent_uuid[0]}
-            for fsname in ${zfsMntent_fsname[@]};do
-                if (get_dataset_status "${fsname}");then
-                    echo "Adding omvzfsplugin:uuid property to ${fsname} dataset"
-                    zfs set 'omvzfsplugin:uuid='"${zfsMntent_uuid[$j]}" "${fsname}"
-                else 
-                    echo "Dataset ${fsname} is not available, skipping...."
-                fi
-                let "++j"
-            done
+        if dpkg --compare-versions "$2" lt-nl "4.0.3"; then
+            if modinfo zfs >/dev/null 2>/dev/null && ! modprobe -n --first-time zfs 2>/dev/null; then
+                zfsMntent_entries=$(omv-confdbadm read conf.system.filesystem.mountpoint \
+                    | jq -r '.[]|select(.type=="zfs")')
+                zfsMntent_uuid=( $(echo "$zfsMntent_entries" | jq -r '.uuid') )
+                zfsMntent_fsname=( $(echo "$zfsMntent_entries" | jq -r '.fsname') )
+                j=0
+                echo ${zfsMntent_uuid[0]}
+                for fsname in ${zfsMntent_fsname[@]};do
+                    if (get_dataset_status "${fsname}");then
+                        echo "Adding omvzfsplugin:uuid property to ${fsname} dataset"
+                        zfs set 'omvzfsplugin:uuid='"${zfsMntent_uuid[$j]}" "${fsname}"
+                    else 
+                        echo "Dataset ${fsname} is not available, skipping...."
+                    fi
+                    let "++j"
+                done
+            else
+                echo "ZFS module not loaded"
+            fi
         else
-            echo "ZFS module not loaded"
+            echo "New plugin install, not inserting uuid property into existing datasets"
         fi
 
         dpkg-trigger update-fixperms

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,6 +6,12 @@ set -e
 . /usr/share/openmediavault/scripts/helper-functions
 
 
+get_dataset_status ()
+{
+    zfs list "$1" &>/dev/null
+}
+
+
 case "$1" in
     configure)
         SERVICE_XPATH_NAME="zfs"
@@ -23,6 +29,31 @@ case "$1" in
 
         dpkg-trigger update-fixperms
         dpkg-trigger update-locale
+
+        if modinfo zfs >/dev/null 2>/dev/null && ! modprobe -n --first-time zfs \
+            2>/dev/null; then
+            zfsMntent_entries=$(omv-confdbadm read conf.system.filesystem.mountpoint \
+                | jq -r '.[]|select(.type=="zfs")')
+            zfsMntent_uuid=( $(echo "$zfsMntent_entries" | jq -r '.uuid') )
+            zfsMntent_fsname=( $(echo "$zfsMntent_entries" | jq -r '.fsname') )
+            i=$(( `echo ${#zfsMntent_fsname[@]}` - 1 ))
+
+            # echo $i
+            j=0
+            for fsname in ${zfsMntent_fsname[@]};do
+                echo $fsname ${zfsMntent_uuid[$j]}
+                if get_dataset_status ${fsname};then
+                    # echo ${zfsMntent_uuid[$j]}
+                    echo "Adding omvzfsplugin:uuid property to ${fsname} dataset"
+                    echo "zfs set "omvzfsplugin:uuid="${zfsMntent_uuid[$j]} ${fsname}"
+                else 
+                    echo "Dataset ${fsname} is not available, skipping...."
+                fi
+                let j++
+            done
+        else 
+            echo "ZFS module not loaded"
+        fi
 
         ;;
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -27,33 +27,30 @@ case "$1" in
 
         /sbin/modprobe zfs
 
-        dpkg-trigger update-fixperms
-        dpkg-trigger update-locale
-
-        if modinfo zfs >/dev/null 2>/dev/null && ! modprobe -n --first-time zfs \
-            2>/dev/null; then
+        if modinfo zfs >/dev/null 2>/dev/null && ! modprobe -n --first-time zfs 2>/dev/null; then
             zfsMntent_entries=$(omv-confdbadm read conf.system.filesystem.mountpoint \
                 | jq -r '.[]|select(.type=="zfs")')
             zfsMntent_uuid=( $(echo "$zfsMntent_entries" | jq -r '.uuid') )
             zfsMntent_fsname=( $(echo "$zfsMntent_entries" | jq -r '.fsname') )
-            i=$(( `echo ${#zfsMntent_fsname[@]}` - 1 ))
-
-            # echo $i
             j=0
+            echo ${zfsMntent_uuid[0]}
             for fsname in ${zfsMntent_fsname[@]};do
-                echo $fsname ${zfsMntent_uuid[$j]}
-                if get_dataset_status ${fsname};then
-                    # echo ${zfsMntent_uuid[$j]}
+                if (get_dataset_status "${fsname}");then
                     echo "Adding omvzfsplugin:uuid property to ${fsname} dataset"
-                    echo "zfs set "omvzfsplugin:uuid="${zfsMntent_uuid[$j]} ${fsname}"
+                    zfs set 'omvzfsplugin:uuid='"${zfsMntent_uuid[$j]}" "${fsname}"
                 else 
                     echo "Dataset ${fsname} is not available, skipping...."
                 fi
-                let j++
+                let "++j"
             done
-        else 
+        else
             echo "ZFS module not loaded"
         fi
+
+        dpkg-trigger update-fixperms
+        dpkg-trigger update-locale
+
+
 
         ;;
 

--- a/usr/share/omvzfs/Dataset.php
+++ b/usr/share/omvzfs/Dataset.php
@@ -183,4 +183,17 @@ abstract class OMVModuleZFSDataset {
 		$this->updateProperty($property);
 	}
 
+	/**
+	 * Sets a custom property for storing mntent uuid. 
+	 *
+	 * @param  string internal database uuid of the mntent entry.
+	 * @return void
+	 * @access public
+	 */
+	public function setMntentProperty($mntent_uuid) {
+		$cmd = "zfs set " . "omvzfsplugin:uuid" . "=\"" . $mntent_uuid . "\" \"" . $this->name . "\" 2>&1";
+		OMVModuleZFSUtil::exec($cmd,$out,$res);
+	}
+
+
 }

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -175,7 +175,7 @@ class OMVModuleZFSUtil {
             $filesystem->updateProperty("mountpoint");
             $name = $filesystem->getName();
             $mntpoint = $filesystem->getMountPoint();
-            if (($mntpoint != "none") && ($mntpoint !== "legacy") && strpos($name, '/')) {
+            if (($mntpoint != "none") && ($mntpoint !== "legacy") && ($mntpoint !== "/")) {
                 $cmd = "mountpoint -q " . $mntpoint;
                 try
                 {

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -550,7 +550,7 @@ class OMVModuleZFSUtil {
 
 
         /**
-         * Create pool config from parsed input
+         * Check if the pool is imported
          *
          * @param string $name Pool name
          * @return boolean

--- a/usr/share/omvzfs/Zpool.php
+++ b/usr/share/omvzfs/Zpool.php
@@ -5,7 +5,7 @@ require_once("Zvol.php");
 require_once("VdevType.php");
 require_once("Utils.php");
 require_once("Exception.php");
-
+require_once("Dataset.php");
 /**
  * Class containing information about the pool
  *
@@ -574,6 +574,8 @@ class OMVModuleZFSZpool extends OMVModuleZFSFilesystem {
         }
         $cmd = "zpool create $opts \"$name\" $cmd 2>&1";
         OMVModuleZFSUtil::exec($cmd,$output,$result);
+        $uuid = \OMV\Environment::get("OMV_CONFIGOBJECT_NEW_UUID");
+        // $tmp->setMntentProperty($uuid);
         return new OMVModuleZFSZpool($name);
     }
     /**
@@ -647,5 +649,8 @@ class OMVModuleZFSZpool extends OMVModuleZFSFilesystem {
         }
         return null;
     }
+
+
+
 }
 ?>

--- a/usr/share/openmediavault/engined/rpc/zfs.inc
+++ b/usr/share/openmediavault/engined/rpc/zfs.inc
@@ -217,6 +217,8 @@ class OMVRpcServiceZFS extends ServiceAbstract {
                     $properties = array("mountpoint"=>$params['mountpoint']);
                     $tmp->setProperties($properties);
                 }
+                // $mntent_uuid = \OMV\Uuid::uuid4();
+                // OMVModuleZFSUtil::setMntentProperty($mntent_uuid,$name);
                 $this->dispatcher->notify(OMV_NOTIFY_MODIFY,
                   "org.openmediavault.storage.zfs.filesystem", $context);
                 break;


### PR DESCRIPTION
This is PR for fixing the issue present when the pool is not available and leaves orphaned shared folders.

The postinst script routine that inserts the uuid needs a version check due to the fact that is made for upgrades not new installs.