### PR TITLE
Allow to use devices with complex names when aliasing "by-id"

### DIFF
--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -49,7 +49,7 @@ class OMVModuleZFSUtil {
         $cmd = "ls -la /dev/disk/by-id/" . $id;
         OMVModuleZFSUtil::exec($cmd,$out,$res);
         if (count($out) === 1) {
-            if (preg_match('/^.*\/([a-z0-9]+.*)$/', $out[0], $match)) {
+            if (preg_match('/^.*\/([A-Za-z0-9]+.*)$/', $out[0], $match)) {
                 $disk = $match[1];
                 return($disk);
             }

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -14,6 +14,11 @@ use OMV\Uuid;
  */
 class OMVModuleZFSUtil {
 
+    /**
+     * @var  REGEX_DEVBYID_DEVNAME
+     * @access public
+     */
+	const REGEX_DEVBYID_DEVNAME = "/^.*\/([A-Za-z0-9]+.*)$/";
 
     /**
      * Sets a GPT label on a disk to prevent the zpool command from generating
@@ -49,7 +54,7 @@ class OMVModuleZFSUtil {
         $cmd = "ls -la /dev/disk/by-id/" . $id;
         OMVModuleZFSUtil::exec($cmd,$out,$res);
         if (count($out) === 1) {
-            if (preg_match('/^.*\/([A-Za-z0-9]+.*)$/', $out[0], $match)) {
+            if (preg_match(OMVModuleZFSUtil::REGEX_DEVBYID_DEVNAME, $out[0], $match)) {
                 $disk = $match[1];
                 return($disk);
             }
@@ -130,7 +135,7 @@ class OMVModuleZFSUtil {
      * @return string Disk identifier
      */
     public static function getDiskId($disk) {
-        preg_match("/^.*\/([A-Za-z0-9]+.*)$/", $disk, $identifier);
+        preg_match(OMVModuleZFSUtil::REGEX_DEVBYID_DEVNAME, $disk, $identifier);
         $cmd = "ls -la /dev/disk/by-id | grep '" . preg_quote($identifier[1]) . "$'";
         OMVModuleZFSUtil::exec($cmd, $out, $res);
         if (is_array($out)) {

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -130,7 +130,7 @@ class OMVModuleZFSUtil {
      * @return string Disk identifier
      */
     public static function getDiskId($disk) {
-        preg_match("/^.*\/([A-Za-z0-9]+)$/", $disk, $identifier);
+        preg_match("/^.*\/([A-Za-z0-9]+.*)$/", $disk, $identifier);
         $cmd = "ls -la /dev/disk/by-id | grep '" . preg_quote($identifier[1]) . "$'";
         OMVModuleZFSUtil::exec($cmd, $out, $res);
         if (is_array($out)) {

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -15,6 +15,9 @@ use OMV\Uuid;
 class OMVModuleZFSUtil {
 
     /**
+     * Regex matching the "/dev/DEVICENAME" strings.
+     * DEVICENAME can be retrieved from the first capture group.
+     *
      * @var  REGEX_DEVBYID_DEVNAME
      * @access public
      */

--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -50,7 +50,7 @@ class OMVModuleZFSUtil {
     }
 
     /**
-     * Get the /dev/sdX device name from /dev/disk/by-id
+     * Get the /dev/DEVNAME device name from /dev/disk/by-id
      *
      */
     public static function getDevByID($id) {
@@ -133,7 +133,7 @@ class OMVModuleZFSUtil {
     }
 
     /**
-     * Get /dev/disk/by-id from /dev/sdX
+     * Get /dev/disk/by-id from /dev/DEVNAME
      *
      * @return string Disk identifier
      */


### PR DESCRIPTION
Resolves #52 

Basically, allows device names to contains signs like dashes or underscores when matching their names in ``getDevId()`` (which for some reason was already used in ``getDevByID()``, but not the "discovery helper" itself). This should allow to eg. create pools on LUKS-encrypted devices (that are usually called ``/dev/dm-0``, ``/dev/dm-1`` and so on) and use their IDs, instead of raw dev names.

I also took the liberty of reformatting the Utils file a bit, as the formatting was all over the place. Now it should be mostly consistent with what seems to be the default approach (but bear in mind that it was based on my hunch and a brief look at other files). The reformatting takes place in the last commit, so it can be easily reverted if needed. I would strongly suggest adding some kind of a linter to the repo (however, I'm not a PHP programmer on a daily basis, so I don't know what tools could be used to do that).