### PR TITLE
Support for Root on ZFS with separate rpool and bpool and cleaning up Shared folders from systems pools

### DIFF
--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -172,19 +172,18 @@ class OMVModuleZFSUtil {
         foreach ($filesystems as $filesystem) {
             $filesystem->updateProperty("mountpoint");
             $name = $filesystem->getName();
-            $mntpoint = $filesystem->getMountPoint();
-            if (($mntpoint != "none") && ($mntpoint !== "legacy") && ($mntpoint !== "/")) {
-                $cmd = "mountpoint -q " . $mntpoint;
-                try
-                {
-                    OMVModuleZFSUtil::exec($cmd, $out, $res);
-                }
-                catch(Exception $e)
-                {
-                    continue;
-                }
-                $current[] = ["fsname" => $name, "dir" => $mntpoint];
-            }
+	    if((substr($name, 0, 5) !== "rpool") && (substr($name, 0, 5) !== "bpool")) {
+                $mntpoint = $filesystem->getMountPoint();
+	        if (($mntpoint != "none") && ($mntpoint !== "legacy")) {
+	            $cmd = "mountpoint -q " . $mntpoint;
+            	    try {
+                	OMVModuleZFSUtil::exec($cmd, $out, $res);
+            	    } catch(Exception $e) {
+                	continue;
+            	    }
+            	    $current[] = ["fsname" => $name, "dir" => $mntpoint];
+        	}
+	    }
         }
         $prev = Rpc::call("FsTab", "enumerateEntries", [], $context);
         $prev = array_filter($prev, function ($element) {


### PR DESCRIPTION
Debian installed from [this HowTo](https://openzfs.github.io/openzfs-docs/Getting%20Started/Debian/Debian%20Buster%20Root%20on%20ZFS.html#step-3-system-installation) have a 2 separate system pools - rpool and bpool