### PR TITLE
Added check to only update shared folders with matching path

### DIFF
--- a/usr/share/omvzfs/Utils.php
+++ b/usr/share/omvzfs/Utils.php
@@ -241,8 +241,15 @@ class OMVModuleZFSUtil {
                 $tmp->updateAllProperties();
                 $old_uuid = $tmp->getProperty("omvzfsplugin:uuid")['value'];
                 $new_uuid = $dataset['uuid'];
+                // Only update shared folders whose path matches this dataset's mountpoint exactly
+                $mountpoint = $tmp->getMountPoint();
                 if ($old_uuid != $new_uuid) {
-                    OMVModuleZFSUtil::fixOMVSharedFolders($old_uuid, $new_uuid, $sf_objects, $context);
+                    $matching_sfs = array_filter($sf_objects, function ($sf) use ($mountpoint) {
+                        return isset($sf['reldirpath']) && rtrim($sf['mntent']['dir'].'/'.$sf['reldirpath'],'/') === $mountpoint;
+                    });
+                    if (!empty($matching_sfs)) {
+                        OMVModuleZFSUtil::fixOMVSharedFolders($old_uuid, $new_uuid, $matching_sfs, $context);
+                    }
                 }
                 OMVModuleZFSUtil::setMntentProperty($dataset['uuid'], $dataset['fsname']);
             }


### PR DESCRIPTION
I have added a check to only update shared folders that match the mount path exactly, whenever a new dataset is added. This should fix issue #83 (https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-zfs/issues/83)
The issue was also described here: https://forum.openmediavault.org/index.php?thread/51475-zfs-plugin-why-are-all-shared-folders-moved-to-a-newly-created-nested-filesystem/&postID=382391#post382391

I'm still a newbie with contributions (and PHP), so please review carefully. I tested it on a VM and the code change seems to work as intended, but it might be that I am missing something about the original intended behavior. Full disclosure: I used VS Codepilot (GPT 4.1) to help me identify the issue and come up with the required adjustments (which I then further adjusted to actually make them work).