### PR TITLE
Remove redundant libzfs6linux dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Architecture: any
 Depends: openmediavault (>= 8),
          zfsutils-linux,
          zfs-zed,
-         libzfs6linux,
          omv-zfs-provider-pve [amd64] | omv-zfs-provider-dkms | zfs-dkms,
          ${misc:Depends}
 Description: OpenMediaVault plugin for ZFS


### PR DESCRIPTION
APT (dpkg) resolves dependencies transitively – libzfs6linux is already a dependency of zfsutils-linux and so its inclusion as its own dependency is redundant.

Additionally, this commit somewhat adds some future proofing. The future zfsutils-linux 2.4.0 package will depend on libzfs7linux not libzfs6linux, and so removing changeable numbered versions of packages (already implicitly included as transitive dependencies), reduces the future need to update this file.